### PR TITLE
Allow Keccak Verifier Circuit to have any inputs

### DIFF
--- a/gnark/ffi_test.go
+++ b/gnark/ffi_test.go
@@ -15,10 +15,10 @@ func TestKeccakInit(t *testing.T) {
 	}
 	ptr := KeccacheckInit(inputs)
 	words := unsafe.Slice((*uint64)(ptr), 600*n)
-	for i := range n {
-		for j := range 25 {
+	for j := range 25 {
+		for i := range n {
 			expected := outputValues[j]
-			actual := words[600*i+575+j]
+			actual := words[575*n+j*n+i]
 			if actual != expected {
 				t.Errorf("Expected word 600 to be %#x, got %#x", expected, actual)
 			}

--- a/gnark/keccak_verifier_test.go
+++ b/gnark/keccak_verifier_test.go
@@ -19,17 +19,21 @@ func TestKeccakVerify(t *testing.T) {
 
 	inputs := make([]*big.Int, 25*N)
 	for i := range inputs {
-		inputs[i] = big.NewInt(0)
+		inputs[i] = big.NewInt(int64(i))
 	}
-
 	var inputDSized [64 * 25 * N]frontend.Variable
 	var inputSized [25 * N]frontend.Variable
-	for i := 0; i < 25*N; i++ {
-		inputSized[i] = inputs[i]
-		w := inputs[i]
-		for j := 0; j < 64; j++ {
-			bit := w.Bit(j)
-			inputDSized[64*i+j] = frontend.Variable(bit)
+	// TODO: simplify this
+	// inputs are currently instance by instance sequentially
+	// But decomposed inputs are stored round by round
+	for i := 0; i < 25; i++ {
+		for instance := 0; instance < N; instance++ {
+			inputSized[instance*25+i] = inputs[instance*25+i]
+			w := inputs[instance*25+i]
+			for j := 0; j < 64; j++ {
+				bit := w.Bit(j)
+				inputDSized[64*(i*N+instance)+j] = frontend.Variable(bit)
+			}
 		}
 	}
 
@@ -40,10 +44,10 @@ func TestKeccakVerify(t *testing.T) {
 
 	for i := 0; i < 25; i++ {
 		for instance := 0; instance < N; instance++ {
-			w := words[575+i]
+			w := words[575*N+i*N+instance]
 			for j := 0; j < 64; j++ {
 				bit := (w >> j) & 1
-				flatIndex := i*N*64 + instance*64 + j
+				flatIndex := 64*(i*N+instance) + j
 				outputSized[flatIndex] = frontend.Variable(bit)
 			}
 		}

--- a/gnark/main.go
+++ b/gnark/main.go
@@ -35,17 +35,19 @@ func main() {
 
 	inputs := make([]*big.Int, 25*N)
 	for i := range inputs {
-		inputs[i] = big.NewInt(0)
+		inputs[i] = big.NewInt(int64(i))
 	}
 
 	var inputDSized [64 * 25 * N]frontend.Variable
 	var inputSized [25 * N]frontend.Variable
-	for i := 0; i < 25*N; i++ {
-		inputSized[i] = inputs[i]
-		w := inputs[i]
-		for j := 0; j < 64; j++ {
-			bit := w.Bit(j)
-			inputDSized[64*i+j] = frontend.Variable(bit)
+	for i := 0; i < 25; i++ {
+		for instance := 0; instance < N; instance++ {
+			inputSized[instance*25+i] = inputs[instance*25+i]
+			w := inputs[instance*25+i]
+			for j := 0; j < 64; j++ {
+				bit := w.Bit(j)
+				inputDSized[64*(i*N+instance)+j] = frontend.Variable(bit)
+			}
 		}
 	}
 
@@ -56,11 +58,10 @@ func main() {
 
 	for i := 0; i < 25; i++ {
 		for instance := 0; instance < N; instance++ {
-			w := words[575+i]
+			w := words[575*N+i*N+instance]
 			for j := 0; j < 64; j++ {
 				bit := (w >> j) & 1
-				flatIndex := i*N*64 + instance*64 + j
-				outputSized[flatIndex] = frontend.Variable(bit)
+				outputSized[64*(i*N+instance)+j] = frontend.Variable(bit)
 			}
 		}
 	}

--- a/rust/benchmark/src/main.rs
+++ b/rust/benchmark/src/main.rs
@@ -3,7 +3,6 @@ use ark_bn254::Fr;
 use gkr::{
     prover::prove,
     reference::STATE,
-    sumcheck::util::{eval_mle, to_poly},
     verifier::verify,
 };
 use std::env;
@@ -42,16 +41,4 @@ fn main() {
     }
 
     println!("OK.");
-
-    let poly = to_poly(&[10]);
-    let r = vec![
-        Fr::from(2),
-        Fr::from(3),
-        Fr::from(4),
-        Fr::from(5),
-        Fr::from(6),
-        Fr::from(7),
-    ];
-    let eval = eval_mle(&poly, &r);
-    println!("poly {poly:?} r {r:?} eval {eval:?}");
 }

--- a/rust/benchmark/src/main.rs
+++ b/rust/benchmark/src/main.rs
@@ -1,10 +1,6 @@
 use ark_bn254::Fr;
 
-use gkr::{
-    prover::prove,
-    reference::STATE,
-    verifier::verify,
-};
+use gkr::{prover::prove, reference::STATE, verifier::verify};
 use std::env;
 
 fn main() {

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -236,27 +236,24 @@ mod tests {
         ];
         const N: usize = 16;
         let output = output.map(u64::swap_bytes);
-        let mut data = [0u64; N * 50];
-
-        for i in 0..N {
-            data[N * 25 + i * 25..N * 25 + i * 25 + 25].copy_from_slice(&output);
-        }
+        let data = [0u64; N * 25];
 
         let ptr: *const [u64] = &data;
 
-        let result: *mut c_void = unsafe { keccacheck_init(ptr as *const u8, N * 400) };
+        let result: *mut c_void = unsafe { keccacheck_init(ptr as *const u8, N * 200) };
         assert!(!result.is_null());
         let words: &[u64] = unsafe { slice::from_raw_parts(result as *const u64, 600 * N) };
-        for i in 0..N {
-            for j in 0..25 {
+
+        for j in 0..25 {
+            for i in 0..N {
                 let expected = output[j];
-                let actual = words[600 * i + 575 + j];
+                let actual = words[575 * N + j * N + i];
                 assert_eq!(
                     actual.swap_bytes(),
                     expected,
                     "Mismatch at instance {}, word {}, expected {:016x}, got {:016x}",
                     i,
-                    575 + j,
+                    575 * N + j * N + i,
                     expected,
                     actual
                 );

--- a/rust/ffi/src/lib.rs
+++ b/rust/ffi/src/lib.rs
@@ -47,15 +47,12 @@ pub unsafe extern "C" fn keccacheck_init(ptr: *const u8, len: usize) -> *mut c_v
         // For each instance we have 25 * 24 = 600 words
         let mut state_data: Vec<u64> = Vec::with_capacity(600 * n);
 
-        for i in 0..n {
-            let input_i = &mut input[25 * i..25 * i + 25];
-            let mut state = KeccakRoundState::at_round(input_i, 0);
-            for _ in 0..23 {
-                state_data.extend_from_slice(state.iota.as_slice());
-                state = state.next();
-            }
+        let mut state = KeccakRoundState::at_round(&input, 0);
+        for _ in 0..23 {
             state_data.extend_from_slice(state.iota.as_slice());
+            state = state.next();
         }
+        state_data.extend_from_slice(state.iota.as_slice());
 
         let mut instance = KeccakInstance { data: state_data };
 


### PR DESCRIPTION
Previously, needed either to have 1 instance. Or multiple instances when all the input buffers were one number repeated. 